### PR TITLE
doc: test: Fix panic in doc example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,14 +557,18 @@ impl<'a> Extcap<'a> {
         };
 
         // Log initialization
-        let debug = self.get_matches().is_present(OPT_DEBUG);
-        let debug_file = self.get_matches().value_of(OPT_DEBUG_FILE).and_then(|s| {
-            if s.trim().is_empty() {
-                None
-            } else {
-                Some(s)
-            }
-        });
+        let debug = self.ifc_debug && self.get_matches().contains_id(OPT_DEBUG);
+        let debug_file = if self.ifc_debug {
+            self.get_matches().value_of(OPT_DEBUG_FILE).and_then(|s| {
+                if s.trim().is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
+            })
+        } else {
+            None
+        };
         listener.init_log(self, debug, debug_file);
         debug!("=======================");
         debug!(


### PR DESCRIPTION
The exmaple provided in src/lib.rs panics because the code attempts look for debug args when the interface does not have one. Fix this issue by guarding these calls with the bool self.ifc_debug which indactes the presnesce of those options.

Fixes: #4